### PR TITLE
Omit faulty job

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -19,4 +19,4 @@ jobs:
       - name: Build
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: build
+          arguments: build -x FtcRobotController:verifyReleaseResources


### PR DESCRIPTION
Judging by the fact that it built correctly, it seems to have worked. Omitted job `:FtcRobotController:verifyReleaseResources` that was causing problems 